### PR TITLE
Remove unnecessary casting in ElectricalSystem

### DIFF
--- a/src/org/impact2585/frc2016/systems/ElectricalSystem.java
+++ b/src/org/impact2585/frc2016/systems/ElectricalSystem.java
@@ -34,9 +34,6 @@ public class ElectricalSystem implements RobotSystem, Runnable{
 	 */
 	@Override
 	public void destroy() {
-		if(panel instanceof SensorBase) {
-			SensorBase powerPanel = (SensorBase) panel;
-			powerPanel.free();
-		}
+		panel.free();
 	}
 }


### PR DESCRIPTION
The casting in `ElectricalSystem` was not necessary as `PowerDistributionPanel` is a subclass of `SensorBase`.
