### PR TITLE
Add limit switches to the arm and intake systems

### DIFF
--- a/src/org/impact2585/frc2016/RobotMap.java
+++ b/src/org/impact2585/frc2016/RobotMap.java
@@ -18,6 +18,10 @@ public interface RobotMap {
 	public static final int INTAKE_LEFT_ARM = 9;
 	public static final int INTAKE_RIGHT_ARM = 0;
 
+	public static final int ARM_LIMIT_SWITCH = 1;
+	public static final int LEFT_INTAKE_LIMIT_SWITCH = 2;
+	public static final int RIGHT_INTAKE_LIMIT_SWITCH = 3;
+	
 	public static final AutonomousExecuter CURRENT_AUTON = AutonomousExecuter.BASIC;
 	
 

--- a/src/org/impact2585/frc2016/input/InputMethod.java
+++ b/src/org/impact2585/frc2016/input/InputMethod.java
@@ -125,13 +125,13 @@ public abstract class InputMethod {
 	 */
 	public double moveIntake() {
 		if(digitalMoveIntakeAwayFromBot() && !digitalMoveIntakeTowardsBot()) {
-			return -1;
+			return 1;
 		} else if (digitalMoveIntakeTowardsBot() && !digitalMoveIntakeAwayFromBot()) {
-			return 1; 
+			return -1; 
 		} else if((analogMoveIntakeAwayFromBot() > 0 && analogMoveIntakeTowardsBot() == 0)) {
-			return -analogMoveIntakeAwayFromBot();
+			return analogMoveIntakeAwayFromBot();
 		} else if (analogMoveIntakeTowardsBot() > 0 && analogMoveIntakeAwayFromBot() == 0) {
-			return analogMoveIntakeTowardsBot();
+			return -analogMoveIntakeTowardsBot();
 		} else {
 			return 0;
 		}

--- a/src/org/impact2585/frc2016/systems/ArmSystem.java
+++ b/src/org/impact2585/frc2016/systems/ArmSystem.java
@@ -4,6 +4,7 @@ import org.impact2585.frc2016.Environment;
 import org.impact2585.frc2016.RobotMap;
 import org.impact2585.frc2016.input.InputMethod;
 
+import edu.wpi.first.wpilibj.DigitalInput;
 import edu.wpi.first.wpilibj.SensorBase;
 import edu.wpi.first.wpilibj.Spark;
 import edu.wpi.first.wpilibj.SpeedController;
@@ -21,6 +22,7 @@ public class ArmSystem implements RobotSystem, Runnable{
 	public static final double TOP_ARM_SPEED = 0.7;
 	private boolean disableSpeedMultiplier;
 	private boolean prevSpeedToggle;
+	private DigitalInput limitswitch;
 	
 
 	/* (non-Javadoc)
@@ -32,6 +34,7 @@ public class ArmSystem implements RobotSystem, Runnable{
 		input = env.getInput();
 		topArm = new Spark(RobotMap.TOP_ARM);
 		bottomArm = new Spark(RobotMap.BOTTOM_ARM);
+		limitswitch = new DigitalInput(RobotMap.ARM_LIMIT_SWITCH);
 		disableSpeedMultiplier = false;
 		prevSpeedToggle = false;
 	}
@@ -49,6 +52,13 @@ public class ArmSystem implements RobotSystem, Runnable{
 	 */
 	public void setBottomArmSpeed(double speed) {
 		bottomArm.set(speed);
+	}
+	
+	/**
+	 * @returns true if the limitswitch is closed, false if open
+	 */
+	public boolean isSwitchClosed() {
+		return limitswitch.get();
 	}
 	
 	/**sets the input method of the arm system
@@ -73,6 +83,10 @@ public class ArmSystem implements RobotSystem, Runnable{
 			bottomarmspeed *= BOTTOM_ARM_SPEED;
 		}
 		
+		if(isSwitchClosed() && bottomarmspeed > 0) {
+			bottomarmspeed = 0;
+		}
+		
 		setTopArmSpeed(toparmspeed);
 		setBottomArmSpeed(bottomarmspeed);
 		prevSpeedToggle = input.toggleSpeed();
@@ -92,6 +106,7 @@ public class ArmSystem implements RobotSystem, Runnable{
 			SensorBase motor = (SensorBase) topArm;
 			motor.free();
 		}
+		limitswitch.free();
 	}
 
 

--- a/src/org/impact2585/frc2016/systems/ElectricalSystem.java
+++ b/src/org/impact2585/frc2016/systems/ElectricalSystem.java
@@ -3,7 +3,6 @@ package org.impact2585.frc2016.systems;
 import org.impact2585.frc2016.Environment;
 
 import edu.wpi.first.wpilibj.PowerDistributionPanel;
-import edu.wpi.first.wpilibj.SensorBase;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
 /**

--- a/src/org/impact2585/frc2016/systems/IntakeSystem.java
+++ b/src/org/impact2585/frc2016/systems/IntakeSystem.java
@@ -4,6 +4,7 @@ import org.impact2585.frc2016.Environment;
 import org.impact2585.frc2016.RobotMap;
 import org.impact2585.frc2016.input.InputMethod;
 
+import edu.wpi.first.wpilibj.DigitalInput;
 import edu.wpi.first.wpilibj.SensorBase;
 import edu.wpi.first.wpilibj.SpeedController;
 import edu.wpi.first.wpilibj.Talon;
@@ -18,6 +19,8 @@ public class IntakeSystem implements RobotSystem, Runnable{
 	private SpeedController rightWheel;
 	private SpeedController leftArm;
 	private SpeedController rightArm;
+	private DigitalInput leftLimitSwitch;
+	private DigitalInput rightLimitSwitch;
 	public static final double ARM_SPEED = 0.3;
 	private boolean disableSpeedMultiplier;
 	private boolean prevSpeedToggle;
@@ -32,6 +35,8 @@ public class IntakeSystem implements RobotSystem, Runnable{
 		rightWheel = new Talon(RobotMap.INTAKE_RIGHT_WHEEL);
 		leftArm = new Talon(RobotMap.INTAKE_LEFT_ARM);
 		rightArm = new Talon(RobotMap.INTAKE_RIGHT_ARM);
+		leftLimitSwitch = new DigitalInput(RobotMap.LEFT_INTAKE_LIMIT_SWITCH);
+		rightLimitSwitch = new DigitalInput(RobotMap.RIGHT_INTAKE_LIMIT_SWITCH);
 		disableSpeedMultiplier = false;
 		prevSpeedToggle = false;
 	}
@@ -50,6 +55,27 @@ public class IntakeSystem implements RobotSystem, Runnable{
 	public void moveArms(double speed) {
 		leftArm.set(speed);
 		rightArm.set(-speed);
+	}
+	
+	/**
+	 * @returns true if the left limit switch is pressed
+	 */
+	public boolean isLeftSwitchClosed() {
+		return leftLimitSwitch.get();
+	}
+	
+	/**
+	 * @returns true if the right limit switch is pressed
+	 */
+	public boolean isRightSwitchClosed() {
+		return rightLimitSwitch.get();
+	}
+	
+	/**
+	 * @returns true if the right or left limit switch is closed
+	 */
+	public boolean isSwitchClosed() {
+		return isRightSwitchClosed() || isLeftSwitchClosed();
 	}
 	
 	/**Sets the input of the system to newInput
@@ -78,6 +104,11 @@ public class IntakeSystem implements RobotSystem, Runnable{
 		if(!disableSpeedMultiplier) {
 			intakeArmSpeed *= ARM_SPEED;
 		}
+		
+		if(isSwitchClosed() && intakeArmSpeed < 0) {
+			intakeArmSpeed = 0;
+		}
+		
 		moveArms(intakeArmSpeed);
 		prevSpeedToggle = input.toggleSpeed();
 	}
@@ -106,6 +137,8 @@ public class IntakeSystem implements RobotSystem, Runnable{
 			SensorBase motor = (SensorBase) rightArm;
 			motor.free();
 		}
+		leftLimitSwitch.free();
+		rightLimitSwitch.free();
 	}
 
 	

--- a/test/org/impact2585/frc2016/tests/ArmSystemTest.java
+++ b/test/org/impact2585/frc2016/tests/ArmSystemTest.java
@@ -22,6 +22,7 @@ public class ArmSystemTest {
 	private TestArmSystem arm;
 	private InputMethod input;
 	private boolean toggleSpeed;
+	private boolean isSwitchClosed;
 
 	/**
 	 * sets up the test
@@ -38,6 +39,7 @@ public class ArmSystemTest {
 		arm = new TestArmSystem();
 		arm.setInput(input);
 		toggleSpeed = false;
+		isSwitchClosed = false;
 	}
 
 	/**
@@ -156,6 +158,34 @@ public class ArmSystemTest {
 		toggleSpeed = true;
 		arm.run();
 		Assert.assertTrue(topArmSpeed == analogTopArmForward && bottomArmSpeed == reversibleBottomArm);
+		
+		//tests if the bottom arm cannot move forward if the limit switch is pressed
+		reversibleBottomArm = 1;
+		isSwitchClosed = true;
+		analogTopArmForward = 0;
+		arm.run();
+		Assert.assertTrue(topArmSpeed == 0 && bottomArmSpeed == 0);
+		
+		//tests if the bottom arm cannot move forward for the non reversible analog values(the triggers) and if the top arm can still move forward
+		reversibleBottomArm = 0;
+		bottomArmForwardValue = 1;
+		analogTopArmForward = 1;
+		arm.run();
+		Assert.assertTrue(topArmSpeed == analogTopArmForward && bottomArmSpeed == 0);
+		
+		//tests if the bottom arm can move back if the limit switch is pressed
+		bottomArmForwardValue = 0;
+		bottomArmBackwardValue = 1;
+		arm.run();
+		Assert.assertTrue(topArmSpeed == analogTopArmForward && bottomArmSpeed == -bottomArmBackwardValue);
+		
+		//tests if the bottom arm can move forward if the limit switch is not pressed
+		isSwitchClosed = false;
+		bottomArmBackwardValue = 0;
+		bottomArmForwardValue = 1;
+		analogTopArmForward = 0;
+		arm.run();
+		Assert.assertTrue(topArmSpeed == 0 && bottomArmSpeed == bottomArmForwardValue);
 	}
 
 	/**
@@ -177,6 +207,14 @@ public class ArmSystemTest {
 		@Override
 		public void setBottomArmSpeed(double speed) {
 			bottomArmSpeed = speed;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.impact2585.frc2016.systems.ArmSystem#isSwitchClosed()
+		 */
+		@Override
+		public boolean isSwitchClosed() {
+			return isSwitchClosed;
 		}
 
 		/* (non-Javadoc)

--- a/test/org/impact2585/frc2016/tests/InputMethodTest.java
+++ b/test/org/impact2585/frc2016/tests/InputMethodTest.java
@@ -91,12 +91,12 @@ public class InputMethodTest {
 		
 		//tests if the input arms move away with analog input
 		analogMoveIntakeAwayFromBot = 1;
-		Assert.assertTrue(input.moveIntake() == -1);
+		Assert.assertTrue(input.moveIntake() == 1);
 		
 		//tests if the input arms move towards the bot with analog input
 		analogMoveIntakeAwayFromBot = 0;
 		analogMoveIntakeTowardsBot = 1;
-		Assert.assertTrue(input.moveIntake() == 1);
+		Assert.assertTrue(input.moveIntake() == -1);
 		
 		//tests if the input arms don't move if Harris presses both triggers
 		analogMoveIntakeAwayFromBot = 1;
@@ -110,12 +110,12 @@ public class InputMethodTest {
 		//tests if the input arms move towards the bot with digital input
 		analogMoveIntakeAwayFromBot = 0;
 		digitalMoveIntakeTowardsBot = true;
-		Assert.assertTrue(input.moveIntake() == 1);
+		Assert.assertTrue(input.moveIntake() == -1);
 		
 		//tests if the input arms move away from the bot with digital input
 		digitalMoveIntakeTowardsBot = false;
 		digitalMoveIntakeAwayFromBot = true;
-		Assert.assertTrue(input.moveIntake() == -1);
+		Assert.assertTrue(input.moveIntake() == 1);
 		
 		//tests if the input arms don't move if Harris presses both buttons
 		digitalMoveIntakeTowardsBot = true;

--- a/test/org/impact2585/frc2016/tests/IntakeSystemTest.java
+++ b/test/org/impact2585/frc2016/tests/IntakeSystemTest.java
@@ -23,6 +23,8 @@ public class IntakeSystemTest {
 	private double wheelSpeed;
 	private double armSpeed;
 	private boolean toggleArmSpeed;
+	private boolean isLeftLimitSwitchClosed;
+	private boolean isRightLimitSwitchClosed;
 	
 	/**
 	 * sets up the intake system test
@@ -39,6 +41,8 @@ public class IntakeSystemTest {
 		analogMoveArmAwayFromBot = 0;
 		analogMoveArmTowardsBot = 0;
 		toggleArmSpeed = false;
+		isLeftLimitSwitchClosed = false;
+		isRightLimitSwitchClosed = false;
 	}
 
 	/**
@@ -70,13 +74,13 @@ public class IntakeSystemTest {
 		moveWheelsBackwards = false;
 		digitalMoveArmAwayFromBot = true;
 		ioshooter.run();
-		Assert.assertTrue(wheelSpeed == 0 && armSpeed == -IntakeSystem.ARM_SPEED);
+		Assert.assertTrue(wheelSpeed == 0 && armSpeed == IntakeSystem.ARM_SPEED);
 		
 		//tests if the arms move backwards
 		digitalMoveArmAwayFromBot = false;
 		digitalMoveArmTowardsBot = true;
 		ioshooter.run();
-		Assert.assertTrue(wheelSpeed == 0 && armSpeed == IntakeSystem.ARM_SPEED);
+		Assert.assertTrue(wheelSpeed == 0 && armSpeed == -IntakeSystem.ARM_SPEED);
 		
 		//tests if the arms don't move if the users pushes both buttons
 		digitalMoveArmAwayFromBot = true;
@@ -87,7 +91,7 @@ public class IntakeSystemTest {
 		digitalMoveArmTowardsBot = false;
 		moveWheelsForward = true;
 		ioshooter.run();
-		Assert.assertTrue(wheelSpeed == 1 && armSpeed == -IntakeSystem.ARM_SPEED);
+		Assert.assertTrue(wheelSpeed == 1 && armSpeed == IntakeSystem.ARM_SPEED);
 		
 		//turn off the digital input
 		moveWheelsForward = false;
@@ -98,13 +102,13 @@ public class IntakeSystemTest {
 		//tests if arms move away with the analog input
 		analogMoveArmAwayFromBot = 1;
 		ioshooter.run();
-		Assert.assertTrue(wheelSpeed == 0 && armSpeed == -IntakeSystem.ARM_SPEED);
+		Assert.assertTrue(wheelSpeed == 0 && armSpeed == IntakeSystem.ARM_SPEED);
 		
 		//tests if the arms move towards the bot with analog input
 		analogMoveArmTowardsBot = 1;
 		analogMoveArmAwayFromBot = 0;
 		ioshooter.run();
-		Assert.assertTrue(wheelSpeed == 0 && armSpeed == IntakeSystem.ARM_SPEED);
+		Assert.assertTrue(wheelSpeed == 0 && armSpeed == -IntakeSystem.ARM_SPEED);
 		
 		//tests if the arms don't move at all if Harris pushes both triggers
 		analogMoveArmAwayFromBot = 1;
@@ -115,16 +119,16 @@ public class IntakeSystemTest {
 		analogMoveArmAwayFromBot = 0;
 		moveWheelsForward = true;
 		ioshooter.run();
-		Assert.assertTrue(wheelSpeed == 1 && armSpeed == IntakeSystem.ARM_SPEED);
+		Assert.assertTrue(wheelSpeed == 1 && armSpeed == -IntakeSystem.ARM_SPEED);
 		
 		//tests if the arm speed multiplier can be toggled off
 		toggleArmSpeed = true;
 		ioshooter.run();
-		Assert.assertTrue(wheelSpeed == 1 && armSpeed == 1);
+		Assert.assertTrue(wheelSpeed == 1 && armSpeed == -1);
 		
 		//tests if the arm speed multiplier doesn't toggle if Harris keeps pushing the button
 		ioshooter.run();
-		Assert.assertTrue(wheelSpeed == 1 && armSpeed == 1);
+		Assert.assertTrue(wheelSpeed == 1 && armSpeed == -1);
 		
 		//tests if the arm speed multiplier toggles on
 		moveWheelsForward = false;
@@ -132,7 +136,7 @@ public class IntakeSystemTest {
 		ioshooter.run();
 		toggleArmSpeed = true;
 		ioshooter.run();
-		Assert.assertTrue(wheelSpeed == 0 && armSpeed == IntakeSystem.ARM_SPEED);
+		Assert.assertTrue(wheelSpeed == 0 && armSpeed == -IntakeSystem.ARM_SPEED);
 		
 		//tests if the arm speed multiplier toggles off for digital input
 		toggleArmSpeed = false;
@@ -141,7 +145,37 @@ public class IntakeSystemTest {
 		digitalMoveArmTowardsBot = true;
 		toggleArmSpeed = true;
 		ioshooter.run();
+		Assert.assertTrue(wheelSpeed == 0 && armSpeed == -1);
+		
+		//tests if the intake arms do not move forward if both limit switches are pressed
+		isLeftLimitSwitchClosed = true;
+		isRightLimitSwitchClosed = true;
+		digitalMoveArmTowardsBot = false;
+		analogMoveArmTowardsBot = 1;
+		ioshooter.run();
+		Assert.assertTrue(wheelSpeed == 0 && armSpeed == 0);
+		
+		//tests if the intake arms do not move forward if only one limit switch is pressed and if the intake still works
+		moveWheelsForward = true;
+		isLeftLimitSwitchClosed = false;
+		analogMoveArmAwayFromBot = 0;
+		analogMoveArmTowardsBot = 1;
+		ioshooter.run();
+		Assert.assertTrue(wheelSpeed == 1 && armSpeed == 0);
+		
+		//tests if the arms can move back if the limit switch is pressed
+		analogMoveArmAwayFromBot = 1;
+		analogMoveArmTowardsBot = 0;
+		moveWheelsForward = false;
+		ioshooter.run();
 		Assert.assertTrue(wheelSpeed == 0 && armSpeed == 1);
+		
+		//tests if the arms can move forward if the limit switch is no longer pressed
+		analogMoveArmTowardsBot = 0.7;
+		analogMoveArmAwayFromBot = 0;
+		isRightLimitSwitchClosed = false;
+		ioshooter.run();
+		Assert.assertTrue(wheelSpeed == 0 && armSpeed == -analogMoveArmTowardsBot);
 	}
 	
 	/**
@@ -163,6 +197,22 @@ public class IntakeSystemTest {
 		@Override
 		public void moveArms(double speed) {
 			armSpeed = speed;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.impact2585.frc2016.systems.IntakeSystem#isLeftSwitchClosed()
+		 */
+		@Override
+		public boolean isLeftSwitchClosed() {
+			return isLeftLimitSwitchClosed;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.impact2585.frc2016.systems.IntakeSystem#isRightSwitchClosed()
+		 */
+		@Override
+		public boolean isRightSwitchClosed() {
+			return isRightLimitSwitchClosed;
 		}
 
 		/* (non-Javadoc)


### PR DESCRIPTION
Two limit switches were added to the intake system for the intake arms and one limit switch was added to the arm system for the bottom arm. These limit switches stop the respective motors in each system from moving forward if a limit switch is pressed. Testing for the limit switches were added in the unit test for each system. This closes #56.
