### PR TITLE
Add the Accelerometer System

### DIFF
--- a/src/org/impact2585/frc2016/Environment.java
+++ b/src/org/impact2585/frc2016/Environment.java
@@ -2,6 +2,7 @@ package org.impact2585.frc2016;
 
 import org.impact2585.frc2016.input.InputMethod;
 import org.impact2585.frc2016.input.PartnerXboxInput;
+import org.impact2585.frc2016.systems.AccelerometerSystem;
 import org.impact2585.frc2016.systems.ArmSystem;
 import org.impact2585.frc2016.systems.ElectricalSystem;
 import org.impact2585.frc2016.systems.IntakeSystem;
@@ -19,6 +20,7 @@ public class Environment extends RobotEnvironment{
 	private ArmSystem arm;
 	private IntakeSystem intake;
 	private ElectricalSystem panel;
+	private AccelerometerSystem accelerometer;
 	
 	/**
 	 * Just a default constructor
@@ -41,6 +43,8 @@ public class Environment extends RobotEnvironment{
 		intake.init(this);
 		panel = new ElectricalSystem();
 		panel.init(this);
+		accelerometer = new AccelerometerSystem();
+		accelerometer.init(this);
 	}
 	
 	/**
@@ -105,6 +109,20 @@ public class Environment extends RobotEnvironment{
 	public void setElectricalSystem(ElectricalSystem electricystem) {
 		panel = electricystem;
 	}
+	
+	/**
+	 * @returns the accelerometer system
+	 */
+	public AccelerometerSystem getAccelerometerSystem() {
+		return accelerometer;
+	}
+	
+	/**sets the accelerometer system to accel
+	 * @param accel new accelerometer system to set
+	 */
+	public void setAccelerometerSystem(AccelerometerSystem accel) {
+		accelerometer = accel;
+	}
 
 	/* (non-Javadoc)
 	 * @see org.impact2585.lib2585.Destroyable#destroy()
@@ -115,6 +133,7 @@ public class Environment extends RobotEnvironment{
 		arm.destroy();
 		intake.destroy();
 		panel.destroy();
+		accelerometer.destroy();
 	}
 	
 }

--- a/src/org/impact2585/frc2016/TeleopExecuter.java
+++ b/src/org/impact2585/frc2016/TeleopExecuter.java
@@ -34,6 +34,7 @@ public class TeleopExecuter extends RunnableExecuter implements Initializable {
 		getRunnables().add(environment.getArmSystem());
 		getRunnables().add(environment.getIntakeSystem());
 		getRunnables().add(environment.getElectricalSystem());
+		getRunnables().add(environment.getAccelerometerSystem());
 	}
 
 }

--- a/src/org/impact2585/frc2016/systems/AccelerometerSystem.java
+++ b/src/org/impact2585/frc2016/systems/AccelerometerSystem.java
@@ -1,0 +1,58 @@
+package org.impact2585.frc2016.systems;
+
+import org.impact2585.frc2016.Environment;
+
+import edu.wpi.first.wpilibj.I2C;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+
+/**
+ * This system gets the accelerometer and gyro values from the MPU6050
+ */
+public class AccelerometerSystem implements RobotSystem, Runnable{
+	public static final int DEVICE_ADDRESS = 0x34;
+	private I2C I2Cbus;
+	private byte buffer[];
+	private short rawValues[];
+
+	/* (non-Javadoc)
+	 * @see org.impact2585.frc2016.Initializable#init(org.impact2585.frc2016.Environment)
+	 */
+	@Override
+	public void init(Environment environ) {
+		I2Cbus = new I2C(I2C.Port.kOnboard, DEVICE_ADDRESS);
+		SmartDashboard.putBoolean("Connection Successful: ", !I2Cbus.addressOnly());
+		
+		buffer = new byte[14];
+		rawValues = new short[6];
+		
+		//sets the gyro and accelerometer ranges
+		I2Cbus.write(0x1B, 0);
+		I2Cbus.write(0x1C, 0);
+		
+	}
+
+	/* (non-Javadoc)
+	 * @see java.lang.Runnable#run()
+	 */
+	@Override
+	public void run() {
+		I2Cbus.read(DEVICE_ADDRESS, 14, buffer);
+		int j = 0;
+		//raw values are ax, ay, az, gx, gy, gz
+		for(int i = 0; i< rawValues.length; i++) {
+			if(j == 3)
+				j++;
+			rawValues[i] = (short) ((((short)buffer[j * 2]) << 8) | buffer[j * 2 + 1]);
+			j++;
+		}
+	}
+	
+	/* (non-Javadoc)
+	 * @see org.impact2585.lib2585.Destroyable#destroy()
+	 */
+	@Override
+	public void destroy() {
+		I2Cbus.free();
+	}
+
+}


### PR DESCRIPTION
The Accelerometer System was added, but there is still work that needs to be done in it. Right now, it can only read raw values from the MPU6050, and more processing will need to be done with it. Currently, init sets the ranges for the accelerometer and gyroscope, but we will later need to have an a write method that will sync the clock of the MPU6050 with the one on the roborio or another one that has a similar frequency.
